### PR TITLE
fix bug, in case the name of one element of the communiaction object …

### DIFF
--- a/de.seronet_projekt.opcua.backend.generator/src/de/seronet_projekt/opcua/backend/generator/commObj/OpcUaCommObjectSelfDescription.xtend
+++ b/de.seronet_projekt.opcua.backend.generator/src/de/seronet_projekt/opcua/backend/generator/commObj/OpcUaCommObjectSelfDescription.xtend
@@ -123,7 +123,7 @@ class OpcUaCommObjectSelfDescription {
 			«FOR attribute: co.attributes»
 				// add «attribute.name»
 				ret->add(
-					SelfDescription(&(obj->«attribute.name.toFirstLower»), "«attribute.name.toFirstUpper»")
+					SelfDescription(&(obj->«attribute.name»), "«attribute.name.toFirstUpper»")
 				);
 			«ENDFOR»
 			return ret;


### PR DESCRIPTION
…start with a capital letter the generated code is inconsistent

I have cases where  the name of an element of a communication object starts with a capital letter. This is valid for SmartSoft (although a warning recommend you don't do so, but still the file is being validated). 

For example http://docs.ros.org/melodic/api/sensor_msgs/html/msg/CameraInfo.html, translated to the SmartSoft DSL:

```
CommObject Sensor_msgs_CameraInfo {
	header : ROSRos_core.Std_msgs_Header
	height : UInt32
	width : UInt32
	distortion_model : String
	D : Double[*]
	K : Double[*]
	R : Double[*]
	P : Double[*]
	binning_x : UInt32
	binning_y : UInt32
	roi : Sensor_msgs_RegionOfInterest
}
```

This generate (automatically using the SmartSoft code generators), the following Sensor_msgs_CameraInfoData.hh :

```
	struct Sensor_msgs_CameraInfo
	{
		ROSRos_coreIDL::Std_msgs_Header header;
		unsigned int height;
		unsigned int width;
		std::string distortion_model;
		Sensor_msgs_CameraInfo_D_type D;
		Sensor_msgs_CameraInfo_K_type K;
		Sensor_msgs_CameraInfo_R_type R;
		Sensor_msgs_CameraInfo_P_type P;
		unsigned int binning_x;
		unsigned int binning_y;
		ROSCommon_msgsIDL::Sensor_msgs_RegionOfInterest roi;
  	};
```

But for the OPC-UA backend the auto generated code for the SelfDescription looks:

```
IDescription::shp_t SelfDescription(ROSCommon_msgsIDL::Sensor_msgs_CameraInfo *obj, std::string name)
{
	auto ret = std::make_shared<SeRoNet::CommunicationObjects::Description::ComplexType>(name);
...
	// add D
	ret->add(
		SelfDescription(&(obj->d), "D")
	);
	// add K
	ret->add(
		SelfDescription(&(obj->k), "K")
	);
	// add R
	ret->add(
		SelfDescription(&(obj->r), "R")
	);
	// add P
	ret->add(
		SelfDescription(&(obj->p), "P")
	);
....
	return ret;
}
```

Obviously this get an error because the name of the element on the object description is, for example, "D" and not "d". 
